### PR TITLE
Add missing file icons

### DIFF
--- a/src/utils/getFileIcon.ts
+++ b/src/utils/getFileIcon.ts
@@ -43,11 +43,15 @@ const extensions = {
   oga: icons.audio,
   opus: icons.audio,
   m4a: icons.audio,
+  wav: icons.audio,
 
   avi: icons.video,
   flv: icons.video,
   mkv: icons.video,
   mp4: icons.video,
+  mov: icons.video,
+  m3u8: icons.video,
+  webm: icons.video,
 
   '7z': icons.archive,
   bz2: icons.archive,
@@ -68,7 +72,7 @@ const extensions = {
   py: icons.code,
   css: icons.code,
   html: icons.code,
-  ts: icons.code,
+  ts: icons.code,   // typescript or video file, determined below
   tsx: icons.code,
   rs: icons.code,
   vue: icons.code,
@@ -85,6 +89,8 @@ const extensions = {
   diff: icons.text,
 
   md: icons.markdown,
+  markdown: icons.markdown,
+  mdown: icons.markdown,
 
   epub: icons.book,
   mobi: icons.book,


### PR DESCRIPTION
The icons for certain file types, such as `.wav`, `.mov`, `.m3u8`, are not displaying correctly. 

Icons have been added to correspond with the file types in `getPreviewType.ts`.

Before:

![image](https://github.com/Vinfall/onedrive-vercel-index/assets/59347549/08962cf2-5fef-4243-8ce6-7eb890ca30ce)


After:

![image](https://github.com/Vinfall/onedrive-vercel-index/assets/59347549/ad90482c-e04c-4423-a3ad-911cfffb2a2b)
